### PR TITLE
Add db_host configuration for remote MySQL servers.

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,7 +19,8 @@ ttvdb_zips_dir = "/pool/myth2kodi/ttvdb/"
 # API key for TheMovieDB
 tmdb_key = "<your tmdb key>"
 
-# MythTV database username, password, and database name
+# MythTV database host, username, password, and database name
+db_host = "localhost"
 db_user = "mythtv"
 db_passwd = "mythtv"
 db_name = "mythconverg"

--- a/myth2kodi.py
+++ b/myth2kodi.py
@@ -137,7 +137,7 @@ def initialize_logging():
 def get_db_cursor():
     global db
     if db is None:
-        db = MySQLdb.connect(host='localhost',
+        db = MySQLdb.connect(host=config.db_host,
                              user=config.db_user,
                              passwd=config.db_passwd,
                              db=config.db_name,


### PR DESCRIPTION
Hopefully I'm doing this pull request correctly! Make the MySQL host parameter a config option.
